### PR TITLE
- UTF8-Support & Tippfehler

### DIFF
--- a/head.tex
+++ b/head.tex
@@ -1,11 +1,12 @@
 \documentclass{article}
 
 \usepackage{longtable}
+\usepackage[utf8]{inputenc}
 
 \begin{document}
 \noindent
 \pagestyle{empty}
-Leistungsempf\"anger\\
+Leistungsempfänger\\
 Apple\\
 Leistungsort \hfill Leistungserbringer\\
 iTunes s.a.r.l. \hfill Erna Mustermann\\

--- a/tail.tex
+++ b/tail.tex
@@ -2,6 +2,6 @@
 
 \vspace{0.5cm}
 \noindent
-Die Steuer auf die erbrachte Leisung ist 0 EUR, da der Leistungsort in
-Luxemburg liegt. Somit ist die Leitung nicht steuerbar.
+Die Steuer auf die erbrachte Leistung ist 0 EUR, da der Leistungsort in
+Luxemburg liegt. Somit ist die Leistung nicht steuerbar.
 \end{document}


### PR DESCRIPTION
- UTF8-Support für tex-files (danke, Finanzamt Bonn-Außenstadt, für deinen tollen Namen)
- Rechtschreibfehler in tail.tex
